### PR TITLE
correct filename for DocBuilder to avoid problem on Linux

### DIFF
--- a/maindoc/CDocBuilder.py
+++ b/maindoc/CDocBuilder.py
@@ -404,7 +404,7 @@ Constructor of class ``CDocBuilder``.
             if bSuccess is not True:
                return bSuccess, CString.FormatResult(sMethod, bSuccess, sResult)
 
-            sDocumentationBuilder = f"{sRepository}/GenPackageDoc.py"
+            sDocumentationBuilder = f"{sRepository}/genpackagedoc.py"
             if os.path.isfile(sDocumentationBuilder) is False:
                bSuccess = False
                sResult  = f"The package doc generator '{sDocumentationBuilder}' does not exist"


### PR DESCRIPTION
Hi Thomas,
Hi @HolQue ,

This change will fix the issue of DocBuilder on Linux #5 .

Thank you,
Ngoan