### PR TITLE
Added command line parameter --configfile

### DIFF
--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -1,8 +1,8 @@
 {
    "REPOSITORYNAME" : "robotframework-documentation",
    "PACKAGENAME" : "RobotFrameworkAIO",
-   "VERSION" : "0.24.0",
-   "VERSION_DATE" : "21.11.2022",
+   "VERSION" : "0.25.0",
+   "VERSION_DATE" : "13.12.2022",
    "AUTHOR" : "Thomas Pollerspöck",
    "AUTHOREMAIL" : "Thomas.Pollerspoeck@de.bosch.com",
    "DESCRIPTION" : "Documentation for RobotFramework AIO",


### PR DESCRIPTION
(for using also other configurations like the default configuration "./maindoc/maindoc_config.json")

A relative path to --configfile has to be relative to the position of the "maindoc" folder.

Every path inside --configfile has to be relative to the position of --configfile.
