### PR TITLE
introduce DOCBUILDER_ARGUMENTS env var to provided args for genmaindoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,22 @@ executed:
             }
     ```
 
-6.  Use the following command to build the documentation:
+6.  Introduce an environment variable \"`DOCBUILDER_ARGUMENTS`\" containing
+    the additional argurment(s) when calling `genmaindoc.py` to generate the
+    document. 
+    
+    It allows to specify another configuration file (contains your specific 
+    configurations for the document) than the default one
+    (located at `maindoc\maindoc_config.json`)
+
+    Example to use \"`DOCBUILDER_ARGUMENTS`\" for using other than default 
+    configuration for building document:
+
+    ``` 
+    export DOCBUILDER_ARGUMENTS="--configfile path/to/other/maindoc_config.json"
+    ```
+
+7.  Use the following command to build the documentation:
 
     ``` 
     setup.py install

--- a/additions/CExtendedSetup.py
+++ b/additions/CExtendedSetup.py
@@ -73,6 +73,8 @@ class CExtendedSetup():
         listCmdLineParts = []
         listCmdLineParts.append(f"\"{sPython}\"")
         listCmdLineParts.append(f"\"{sDocumentationBuilder}\"")
+        if "DOCBUILDER_ARGUMENTS" in os.environ:
+            listCmdLineParts.append(os.environ["DOCBUILDER_ARGUMENTS"])
         sCmdLine = " ".join(listCmdLineParts)
         del listCmdLineParts
         listCmdLineParts = shlex.split(sCmdLine)

--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -1,8 +1,8 @@
 {
    "REPOSITORYNAME" : "robotframework-documentation",
    "PACKAGENAME" : "RobotFrameworkAIO",
-   "VERSION" : "0.26.0",
-   "VERSION_DATE" : "13.12.2022",
+   "VERSION" : "0.27.0",
+   "VERSION_DATE" : "30.12.2022",
    "AUTHOR" : "Thomas Pollerspöck",
    "AUTHOREMAIL" : "Thomas.Pollerspoeck@de.bosch.com",
    "DESCRIPTION" : "Documentation for RobotFramework AIO",


### PR DESCRIPTION
Hi Holger,
Hi Thomas,

The argument `--configfile` is only used with **genmaindoc.py** script and this script is called indirectly (without additional argument) by **setup.py**.

I think passing this argument from **build** => **setup.py** =>**genmaindoc.py** is not a good idea, it is also confused because **build** has `--config-file` for repos configuration.

So that, I add the environment variable `DOCBUILDER_ARGUMENTS` so that you can specify the additional argument (such as config file) for building main document.
Thi env var is only configured for Gitlab CI to use the config file located on Gitlab **build** repo.

Please review and give your idea about it,

Thank you,
Ngoan